### PR TITLE
use raw sql to bypass some orm isses with relationships

### DIFF
--- a/config/db.js
+++ b/config/db.js
@@ -1,5 +1,5 @@
-require('dotenv').config();
-const { Sequelize } = require('sequelize');
+require("dotenv").config();
+const { Sequelize } = require("sequelize");
 
 const sequelize = new Sequelize({
   dialect: "postgres",

--- a/controllers/AuthorizationController/authorize.js
+++ b/controllers/AuthorizationController/authorize.js
@@ -1,6 +1,8 @@
 const User = require("../../models/Users");
 const Permission = require("../../models/Permissions");
 const Role = require("../../models/Roles");
+const RolePermission = require("../../models/RolePermissions");
+const sequelize = require("../../config/db");
 
 const jwt = require("jsonwebtoken");
 
@@ -17,31 +19,41 @@ const authorize = (req, res) => {
         error: "Invalid token",
       });
     }
+
     const { id } = decoded;
 
-    const user = await User.findByPk(id, {
-      include: [
-        {
-          model: Permission,
-          as: "permissions",
-          attributes: ["name"],
-        },
-        {
-          model: Role,
-          as: "role",
-          attributes: ["name"],
-          include: [{ model: Permission, attributes: ["name"] }],
-        },
-      ],
-    });
+    const [users] = await sequelize.query(
+      `SELECT * FROM "user" WHERE id='${id}';`,
+    );
 
-    if (!user) {
+    if (!users.length) {
       return res.status(404).json({
         status: 404,
         authorized: false,
         message: "No user found",
       });
     }
+
+    const user = users[0];
+
+    const [roles] = await sequelize.query(
+      `SELECT * FROM "role" WHERE id='${user.role_id}';`,
+    );
+
+	const role = roles[0];
+
+    const [userPermissions] = await sequelize.query(
+      `SELECT permission.name FROM "user_permission"
+		INNER JOIN "permission" ON user_permission.permission_id = permission.id
+		WHERE user_permission.user_id = '${id}';`,
+    );
+
+    const [rolePermissions] = await sequelize.query(
+      `SELECT permission.name FROM "roles_permissions"
+	 INNER JOIN "permission" ON roles_permissions.permission_id = permission.id 
+	 WHERE roles_permissions.role_id = '${user.role_id}';`,
+    );
+
 
     if (user && !user.is_verified) {
       return res.status(401).json({
@@ -50,13 +62,6 @@ const authorize = (req, res) => {
         message: "user is not verified",
       });
     }
-
-    const userPermissions = user.permissions.map(
-      (permission) => permission.name,
-    );
-    const rolePermissions = user.role.permissions.map(
-      (permission) => permission.name,
-    );
 
     const permissions = [...new Set([...userPermissions, ...rolePermissions])];
 
@@ -67,8 +72,7 @@ const authorize = (req, res) => {
         message: "user is authenticated",
         user: {
           id,
-          role: user.role.name,
-          permissions,
+		  role: role.name,
         },
       };
       return res.status(200).json(response);
@@ -81,8 +85,8 @@ const authorize = (req, res) => {
         message: "user is authorized for this permission",
         user: {
           id,
-          permissions,
-          role: user.role.name,
+		  permissions,
+		  role: role.name,
         },
       };
       return res.status(200).json(response);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const express = require("express");
 const cors = require("cors");
 const session = require("express-session");
 const passport = require("passport");
+const sequelize = require("./config/db");
+
+sequelize.sync();
 
 // routes imports
 const indexRouter = require("./routes/index");

--- a/models/RolePermissions.js
+++ b/models/RolePermissions.js
@@ -1,11 +1,11 @@
-const { DataTypes } = require('sequelize');
-const sequelize = require('../config/db');
+const { DataTypes } = require("sequelize");
+const sequelize = require("../config/db");
 
-const Role = require('./Roles');
-const Permission = require('./Permissions');
+const Role = require("./Roles");
+const Permission = require("./Permissions");
 
 const RolePermissions = sequelize.define(
-  'roles_permissions',
+  "roles_permissions",
   {
     id: {
       type: DataTypes.INTEGER,
@@ -17,14 +17,14 @@ const RolePermissions = sequelize.define(
       type: DataTypes.INTEGER,
       references: {
         model: Role,
-        key: 'id',
+        key: "id",
       },
     },
     permission_id: {
       type: DataTypes.INTEGER,
       references: {
         model: Permission,
-        key: 'id',
+        key: "id",
       },
     },
     createdAt: {
@@ -32,17 +32,19 @@ const RolePermissions = sequelize.define(
       defaultValue: DataTypes.NOW,
     },
   },
-  { freezeTableName: true, timestamps: false }
+  { freezeTableName: true, timestamps: false },
 );
 
 Role.belongsToMany(Permission, {
   through: RolePermissions,
-  foreignKey: 'role_id',
+  foreignKey: "role_id",
+  otherKey: "permission_id",
 });
 
 Permission.belongsToMany(Role, {
   through: RolePermissions,
-  foreignKey: 'permission_id',
+  foreignKey: "permission_id",
+  otherKey: "role_id",
 });
 
 module.exports = RolePermissions;


### PR DESCRIPTION
# Prefer raw SQL to Sequelize ORM queries

## Motivation

After numerous complaints from the other teams on the `/authorize` endpoint, I checked and saw that the ORM was missing and sometimes working right when it came to making relational queries.

When using SQL, the issue seems to be sorted. This PR has resorted to that.
